### PR TITLE
Implements results of next.parallel as dictionary

### DIFF
--- a/index.js
+++ b/index.js
@@ -142,7 +142,7 @@ exports.step = function(funcs, onerror) {
 			next(null, values);
 		}
 	};
-	next.parallel = function() {
+	next.parallel = function(key) {
 		var index = counter++;
 
 		if (complete) {
@@ -150,7 +150,7 @@ exports.step = function(funcs, onerror) {
 		}
 		return function(err, value) {
 			completed++;
-			values[index] = value;
+			values[key ? key : index] = value;
 			next(err, values);
 		};
 	};


### PR DESCRIPTION
This pull request seamlessly integrates a dictionary behaviour to next.parallel as described below.

```
common.step([
  function (next) {
    next.parallel('key')(null, 'value');
  },
  function (results) {
    var key = results.key;
    console.log(key);
  }
]);
```

We think this helps maintain some sanity when doing lots of parallel activity.
